### PR TITLE
[Pull Request] Instruction order of attentions

### DIFF
--- a/src/operations/NeuPIMSAttend.cc
+++ b/src/operations/NeuPIMSAttend.cc
@@ -63,6 +63,7 @@ void NeuPIMSAttend::initialize_tiles() {
     }
 }
 
+
 Tile NeuPIMSAttend::initialize_instructions(int start, int end) {
     auto tile = Tile{
         .status = Tile::Status::INITIALIZED,
@@ -79,8 +80,6 @@ Tile NeuPIMSAttend::initialize_instructions(int start, int end) {
 
         uint32_t seq_len = value->get_dims()[1];
         uint32_t ch = value->get_channel();
-        uint32_t chunks = ceil((double)seq_len / _page_size);
-        // spdlog::info("seq_len: {}", seq_len);
 
         if (logit->get_dims()[1] != 1) {
             // spdlog::info("logit dim:{}", logit->get_dims());
@@ -149,119 +148,124 @@ Tile NeuPIMSAttend::initialize_instructions(int start, int end) {
             continue;
         }
 
+        // Per-head V-attention PIM path.
+        // Layout: _rows[h * rows_per_head + ti * seq_chunks + ci]
+        //   seq_chunks = ceil(seq_len / page_size)  — GWRITE splits score into chunks
+        //   dk_tiles   = ceil(dk / bank_per_ch)     — one READRES per dk tile per chunk
+        //   rows_per_head = dk_tiles × seq_chunks
+        // If seq_chunks > 1: ADD across chunks before MOVOUT (accumulate partial results).
+        uint32_t seq_chunks = (uint32_t)ceil((double)seq_len / _page_size);
+        uint32_t dk_tiles = _tiles_per_chunk;
+        uint32_t rows_per_head = dk_tiles * seq_chunks;
+
         for (int hi = 0; hi < _nh; hi++) {
             std::map<uint32_t, std::vector<addr_type>> sram_readres_addrs;
-            for (int ci = 0; ci < chunks; ci++) {
-                uint64_t logit_row = 0;  // FIXME: decode row index from dram address
-                uint64_t p_header_addr =
-                    AddressConfig::encode_pim_header(ch, logit_row, true, 0, 0);
 
-                addr_type sram_addr_gw = allocate_sram_addr(0, false).first;
+            for (int ci = 0; ci < (int)seq_chunks; ci++) {
+                uint32_t chunk_tokens = (ci == (int)seq_chunks - 1 && seq_len % _page_size > 0)
+                                            ? seq_len % _page_size
+                                            : _page_size;
 
-                // GWRITE (channel, bank, row)
+                // GWRITE: broadcast score[hi][0][ci*page_size..] into GRF
+                addr_type score_addr =
+                    logit->get_addr({(uint32_t)hi, 0, (uint32_t)(ci * _page_size)});
+                addr_type sram_gw = allocate_sram_addr(0, false).first;
                 tile.instructions.push_back(Instruction{
                     .opcode = Opcode::PIM_GWRITE,
-                    .dest_addr = sram_addr_gw,
+                    .dest_addr = sram_gw,
                     .size = 0,
-                    .src_addrs = std::vector<addr_type>{p_header_addr},  // FIXME: gwrite addr
+                    .src_addrs = std::vector<addr_type>{score_addr},
                     .operand_id = _INPUT_OPERAND,
                 });
 
                 uint32_t num_comps =
-                    (ci == chunks - 1 && (seq_len % _page_size) > 0)
-                        ? ceil((double)(seq_len % _page_size) / _datas_per_comp_cmd)
-                        : _page_size / _datas_per_comp_cmd;
+                    (uint32_t)ceil((double)chunk_tokens / _datas_per_comp_cmd);
                 uint32_t decoded_num_comps = 1 << LogBase2(num_comps);
+                if (num_comps > decoded_num_comps) decoded_num_comps *= 2;
+                assert(num_comps <= decoded_num_comps && num_comps > 0);
 
-                // spdlog::info("num_comps: {}, decoded_num_comps: {}", num_comps,
-                // decoded_num_comps);
-                if (num_comps > decoded_num_comps) {
-                    decoded_num_comps *= 2;
-                }
-                assert(num_comps <= decoded_num_comps);
-                assert(num_comps > 0);
-
-                for (int ti = 0; ti < _tiles_per_chunk; ti++) {
-                    auto sram_entry = allocate_sram_addr(_banks_per_channel, false);
-                    addr_type sram_addr = sram_entry.first;
-
-                    uint32_t DRAM_row = value->_rows[ti * chunks + ci];
-                    p_header_addr =
-                        AddressConfig::encode_pim_header(ch, DRAM_row, false, decoded_num_comps, 1);
-                    // P_HEADER (num_comps, num_readres)
+                for (int ti = 0; ti < (int)dk_tiles; ti++) {
+                    uint32_t row_base =
+                        value->_rows[hi * rows_per_head + ti * seq_chunks + ci];
+                    uint32_t p_header_addr = AddressConfig::encode_pim_header(
+                        ch, row_base, false, decoded_num_comps, 1);
+                    addr_type sram_hdr = allocate_sram_addr(0, false).first;
                     tile.instructions.push_back(Instruction{
                         .opcode = Opcode::PIM_HEADER,
-                        .dest_addr = sram_addr,
+                        .dest_addr = sram_hdr,
                         .size = 0,
                         .src_addrs = std::vector<addr_type>{p_header_addr},
                         .operand_id = _INPUT_OPERAND,
                     });
-                    std::string cmds = "P_HEADER ";
 
+                    auto sram_res_entry = allocate_sram_addr(_banks_per_channel, false);
                     uint64_t dram_addr =
-                        AddressConfig::encode_pim_comps_readres(ch, DRAM_row, num_comps, true);
+                        AddressConfig::encode_pim_comps_readres(ch, row_base, num_comps, true);
 
                     if (_config.dram_type == DramType::NEWTON) {
-                        Instruction comp_inst = Instruction{
+                        Instruction comp_inst{
                             .opcode = Opcode::PIM_COMP,
-                            .dest_addr = sram_addr,
+                            .dest_addr = sram_res_entry.first,
                             .size = 0,
                             .src_addrs = std::vector<addr_type>{dram_addr},
                             .operand_id = _INPUT_OPERAND,
                         };
-
-                        for (int j = 0; j < num_comps; j++) {
-                            // COMP * num_comps (channnel, row)
+                        for (int j = 0; j < (int)num_comps; j++)
                             tile.instructions.push_back(comp_inst);
-                            cmds += "COMP ";
-                        }
                         tile.instructions.push_back(Instruction{
                             .opcode = Opcode::PIM_READRES,
-                            .dest_addr = sram_addr,
-                            .size = sram_entry.second,
+                            .dest_addr = sram_res_entry.first,
+                            .size = sram_res_entry.second,
                             .src_addrs = std::vector<addr_type>{dram_addr},
                             .operand_id = _INPUT_OPERAND,
                         });
-                        cmds += "READRES ";
                     } else {
                         tile.instructions.push_back(Instruction{
                             .opcode = Opcode::PIM_COMPS_READRES,
-                            .dest_addr = sram_addr,
-                            .size = sram_entry.second,
+                            .dest_addr = sram_res_entry.first,
+                            .size = sram_res_entry.second,
                             .src_addrs = std::vector<addr_type>{dram_addr},
                             .operand_id = _INPUT_OPERAND,
                         });
                     }
 
-                    if (sram_readres_addrs.find(ti) == sram_readres_addrs.end())  // not exists
-                        sram_readres_addrs[ti] = std::vector<addr_type>{sram_addr};
+                    if (sram_readres_addrs.find(ti) == sram_readres_addrs.end())
+                        sram_readres_addrs[ti] = std::vector<addr_type>{sram_res_entry.first};
                     else
-                        sram_readres_addrs[ti].push_back(sram_addr);
+                        sram_readres_addrs[ti].push_back(sram_res_entry.first);
                 }
             }
-            if (chunks > 1) {
-                for (int ti = 0; ti < _tiles_per_chunk; ++ti) {
-                    assert(sram_readres_addrs[ti].size() == chunks);
 
-                    uint32_t column_height = _tiles_per_chunk * _banks_per_channel;
-                    auto sram_acc_entry = allocate_sram_addr(column_height, true);
+            // Accumulate partial results across seq_chunks, then write output
+            for (int ti = 0; ti < (int)dk_tiles; ti++) {
+                assert(sram_readres_addrs[ti].size() == seq_chunks);
 
+                addr_type final_sram;
+                uint32_t final_size;
+                if (seq_chunks > 1) {
+                    uint32_t col_h = dk_tiles * _banks_per_channel;
+                    auto sram_acc = allocate_sram_addr(col_h, true);
                     tile.instructions.push_back(Instruction{
                         .opcode = Opcode::ADD,
-                        .dest_addr = sram_acc_entry.first,
-                        .size = sram_acc_entry.second,
+                        .dest_addr = sram_acc.first,
+                        .size = sram_acc.second,
                         .src_addrs = sram_readres_addrs[ti],
                     });
-                    tile.instructions.push_back(Instruction{
-                        .opcode = Opcode::MOVOUT,
-                        .dest_addr = sram_acc_entry.first,
-                        .size = sram_acc_entry.second,
-                        .src_addrs = std::static_pointer_cast<NPUTensor>(_outputs[i])
-                                         ->_inners[hi]
-                                         ->get_all_addrs(),
-                        .operand_id = _OUTPUT_OPERAND,
-                    });
+                    final_sram = sram_acc.first;
+                    final_size = sram_acc.second;
+                } else {
+                    final_sram = sram_readres_addrs[ti][0];
+                    final_size = _banks_per_channel;
                 }
+                tile.instructions.push_back(Instruction{
+                    .opcode = Opcode::MOVOUT,
+                    .dest_addr = final_sram,
+                    .size = final_size,
+                    .src_addrs = std::static_pointer_cast<NPUTensor>(_outputs[i])
+                                     ->_inners[hi]
+                                     ->get_all_addrs(),
+                    .operand_id = _OUTPUT_OPERAND,
+                });
             }
         }
     }
@@ -313,6 +317,181 @@ void NeuPIMSAttend::calculate_loops() {
         }
     }
     _req_idxs.push_back(_batch_size - 1);
+}
+
+Tile NeuPIMSAttend::initialize_instructions_legacy(int start, int end) {
+    auto tile = Tile{
+        .status = Tile::Status::INITIALIZED,
+        .optype = get_name(),
+        .operation_id = _id,
+        .batch = 0,
+        .K = 0,
+        .accum = false,
+    };
+
+    for (int i = start; i < end + 1; ++i) {
+        auto logit = _logits[i];
+        auto value = _vs[i];
+
+        uint32_t seq_len = value->get_dims()[1];
+        uint32_t ch = value->get_channel();
+        uint32_t chunks = (uint32_t)ceil((double)seq_len / _page_size);
+
+        if (logit->get_dims()[1] != 1) {
+            assert(logit->get_dims()[1] == seq_len);
+
+            for (int h_idx = 0; h_idx < _nh; h_idx++) {
+                std::vector<addr_type> dram_logit_addrs;
+                std::vector<addr_type> dram_value_addrs;
+
+                for (int dk_idx = 0; dk_idx < _dk; dk_idx++) {
+                    for (int seq_idx = 0; seq_idx < seq_len; seq_idx++) {
+                        dram_value_addrs.push_back(
+                            value->get_addr(std::vector<uint32_t>{h_idx, seq_idx, dk_idx}));
+                        for (int sseq_idx = 0; sseq_idx < seq_len; sseq_idx++) {
+                            dram_logit_addrs.push_back(
+                                logit->get_addr({h_idx, seq_idx, sseq_idx}));
+                        }
+                    }
+                }
+                auto sram_l_entry = allocate_sram_addr(seq_len * seq_len, false);
+                auto sram_v_entry = allocate_sram_addr(seq_len * _dk, false);
+                auto sram_a_entry = allocate_sram_addr(seq_len * _dk, true);
+                tile.instructions.push_back(Instruction{
+                    .opcode = Opcode::MOVIN,
+                    .dest_addr = sram_l_entry.first,
+                    .size = sram_l_entry.second,
+                    .src_addrs = dram_logit_addrs,
+                    .operand_id = _INPUT_OPERAND,
+                });
+                tile.instructions.push_back(Instruction{
+                    .opcode = Opcode::MOVIN,
+                    .dest_addr = sram_v_entry.first,
+                    .size = sram_v_entry.second,
+                    .src_addrs = dram_value_addrs,
+                    .operand_id = _INPUT_OPERAND,
+                });
+                tile.instructions.push_back(Instruction{
+                    .opcode = Opcode::GEMM,
+                    .dest_addr = sram_a_entry.first,
+                    .size = sram_a_entry.second,
+                    .src_addrs = std::vector<addr_type>{sram_l_entry.first, sram_v_entry.first},
+                    .tile_m = _dk,
+                    .tile_k = seq_len,
+                    .tile_n = seq_len,
+                });
+                tile.instructions.push_back(Instruction{
+                    .opcode = Opcode::MOVOUT,
+                    .dest_addr = sram_a_entry.first,
+                    .size = sram_a_entry.second,
+                    .src_addrs = std::static_pointer_cast<NPUTensor>(_outputs[i])
+                                     ->_inners[h_idx]
+                                     ->get_all_addrs(),
+                    .operand_id = _OUTPUT_OPERAND,
+                });
+            }
+            continue;
+        }
+
+        for (int hi = 0; hi < _nh; hi++) {
+            std::map<uint32_t, std::vector<addr_type>> sram_readres_addrs;
+            for (int ci = 0; ci < chunks; ci++) {
+                uint64_t logit_row = 0;  // FIXME: decode row index from dram address
+                uint64_t p_header_addr =
+                    AddressConfig::encode_pim_header(ch, logit_row, true, 0, 0);
+                addr_type sram_addr_gw = allocate_sram_addr(0, false).first;
+                tile.instructions.push_back(Instruction{
+                    .opcode = Opcode::PIM_GWRITE,
+                    .dest_addr = sram_addr_gw,
+                    .size = 0,
+                    .src_addrs = std::vector<addr_type>{p_header_addr},  // FIXME
+                    .operand_id = _INPUT_OPERAND,
+                });
+
+                uint32_t num_comps =
+                    (ci == (int)chunks - 1 && (seq_len % _page_size) > 0)
+                        ? (uint32_t)ceil((double)(seq_len % _page_size) / _datas_per_comp_cmd)
+                        : _page_size / _datas_per_comp_cmd;
+                uint32_t decoded_num_comps = 1 << LogBase2(num_comps);
+                if (num_comps > decoded_num_comps) decoded_num_comps *= 2;
+                assert(num_comps <= decoded_num_comps && num_comps > 0);
+
+                for (int ti = 0; ti < _tiles_per_chunk; ti++) {
+                    auto sram_entry = allocate_sram_addr(_banks_per_channel, false);
+                    addr_type sram_addr = sram_entry.first;
+
+                    uint32_t DRAM_row = value->_rows[ti * chunks + ci];
+                    p_header_addr = AddressConfig::encode_pim_header(
+                        ch, DRAM_row, false, decoded_num_comps, 1);
+                    tile.instructions.push_back(Instruction{
+                        .opcode = Opcode::PIM_HEADER,
+                        .dest_addr = sram_addr,
+                        .size = 0,
+                        .src_addrs = std::vector<addr_type>{p_header_addr},
+                        .operand_id = _INPUT_OPERAND,
+                    });
+
+                    uint64_t dram_addr =
+                        AddressConfig::encode_pim_comps_readres(ch, DRAM_row, num_comps, true);
+
+                    if (_config.dram_type == DramType::NEWTON) {
+                        Instruction comp_inst{
+                            .opcode = Opcode::PIM_COMP,
+                            .dest_addr = sram_addr,
+                            .size = 0,
+                            .src_addrs = std::vector<addr_type>{dram_addr},
+                            .operand_id = _INPUT_OPERAND,
+                        };
+                        for (int j = 0; j < (int)num_comps; j++)
+                            tile.instructions.push_back(comp_inst);
+                        tile.instructions.push_back(Instruction{
+                            .opcode = Opcode::PIM_READRES,
+                            .dest_addr = sram_addr,
+                            .size = sram_entry.second,
+                            .src_addrs = std::vector<addr_type>{dram_addr},
+                            .operand_id = _INPUT_OPERAND,
+                        });
+                    } else {
+                        tile.instructions.push_back(Instruction{
+                            .opcode = Opcode::PIM_COMPS_READRES,
+                            .dest_addr = sram_addr,
+                            .size = sram_entry.second,
+                            .src_addrs = std::vector<addr_type>{dram_addr},
+                            .operand_id = _INPUT_OPERAND,
+                        });
+                    }
+
+                    if (sram_readres_addrs.find(ti) == sram_readres_addrs.end())
+                        sram_readres_addrs[ti] = std::vector<addr_type>{sram_addr};
+                    else
+                        sram_readres_addrs[ti].push_back(sram_addr);
+                }
+            }
+            if (chunks > 1) {
+                for (int ti = 0; ti < _tiles_per_chunk; ++ti) {
+                    assert(sram_readres_addrs[ti].size() == chunks);
+                    uint32_t column_height = _tiles_per_chunk * _banks_per_channel;
+                    auto sram_acc_entry = allocate_sram_addr(column_height, true);
+                    tile.instructions.push_back(Instruction{
+                        .opcode = Opcode::ADD,
+                        .dest_addr = sram_acc_entry.first,
+                        .size = sram_acc_entry.second,
+                        .src_addrs = sram_readres_addrs[ti],
+                    });
+                    tile.instructions.push_back(Instruction{
+                        .opcode = Opcode::MOVOUT,
+                        .dest_addr = sram_acc_entry.first,
+                        .size = sram_acc_entry.second,
+                        .src_addrs = std::static_pointer_cast<NPUTensor>(_outputs[i])
+                                         ->_inners[hi]
+                                         ->get_all_addrs(),
+                        .operand_id = _OUTPUT_OPERAND,
+                    });
+                }
+            }
+        }
+    }
+    return tile;
 }
 
 uint32_t NeuPIMSAttend::sram_size_needed() {

--- a/src/operations/NeuPIMSAttend.h
+++ b/src/operations/NeuPIMSAttend.h
@@ -34,5 +34,8 @@ class NeuPIMSAttend : public Operation {
     void calculate_loops();
     void initialize_tiles();
     Tile initialize_instructions(int start, int end);
+
+    Tile initialize_instructions_legacy(int start, int end);
+
     uint32_t sram_size_needed();
 };

--- a/src/operations/NeuPIMSLogitSoftmax.cc
+++ b/src/operations/NeuPIMSLogitSoftmax.cc
@@ -77,6 +77,229 @@ void NeuPIMSLogitSoftmax::initialize_tiles() {
 Tile NeuPIMSLogitSoftmax::initialize_instructions(int start, int end) {
     uint32_t banks_per_channel = _config.dram_banks_per_ch;
 
+    // PIMTensor KEY layout (per-head): _rows[h * tiles_per_chunk + ti]
+    // One row = 1 head × tokens_per_row tokens; consecutive rows per head.
+    // NewtonSim is latency-only so physical addresses are not significant.
+
+    auto tile = Tile{
+        .status = Tile::Status::INITIALIZED,
+        .optype = get_name(),
+        .operation_id = _id,
+        .batch = 0,
+        .K = 0,
+        .accum = false,
+    };
+
+    int counter_for_debug = 0;
+
+    for (int i = start; i < end + 1; i++) {
+        auto query = _qs[i];
+        auto key = _ks[i];
+
+        if (query->get_dims()[1] != 1) {  // initiation phase: fall back to NPU path
+            uint32_t seq_len = query->get_dims()[1];
+            assert(seq_len == key->get_dims()[2]);
+
+            for (int h_idx = 0; h_idx < _nh; h_idx++) {
+                std::vector<addr_type> dram_query_addrs;
+                std::vector<addr_type> dram_key_addrs;
+
+                for (int dk_idx = 0; dk_idx < _dk; dk_idx++) {
+                    for (int seq_idx = 0; seq_idx < seq_len; seq_idx++) {
+                        dram_query_addrs.push_back(
+                            query->get_addr(std::vector<uint32_t>{(uint32_t)h_idx, (uint32_t)seq_idx, (uint32_t)dk_idx}));
+                        dram_key_addrs.push_back(
+                            key->get_addr(std::vector<uint32_t>{(uint32_t)h_idx, (uint32_t)dk_idx, (uint32_t)seq_idx}));
+                    }
+                }
+                auto sram_q_entry = allocate_sram_addr(seq_len * _dk, false);
+                auto sram_k_entry = allocate_sram_addr(seq_len * _dk, false);
+                auto sram_l_entry = allocate_sram_addr(seq_len * seq_len, true);
+                auto sram_ls_entry = allocate_sram_addr(seq_len * seq_len, true);
+
+                tile.instructions.push_back(Instruction{
+                    .opcode = Opcode::MOVIN,
+                    .dest_addr = sram_q_entry.first,
+                    .size = sram_q_entry.second,
+                    .src_addrs = dram_query_addrs,
+                    .operand_id = _INPUT_OPERAND,
+                });
+                tile.instructions.push_back(Instruction{
+                    .opcode = Opcode::MOVIN,
+                    .dest_addr = sram_k_entry.first,
+                    .size = sram_k_entry.second,
+                    .src_addrs = dram_key_addrs,
+                    .operand_id = _INPUT_OPERAND + 1,
+                });
+                tile.instructions.push_back(Instruction{
+                    .opcode = Opcode::GEMM,
+                    .dest_addr = sram_l_entry.first,
+                    .size = sram_l_entry.second,
+                    .src_addrs = std::vector<addr_type>{sram_q_entry.first, sram_k_entry.first},
+                    .tile_m = seq_len,
+                    .tile_k = _dk,
+                    .tile_n = seq_len,
+                });
+                tile.instructions.push_back(Instruction{
+                    .opcode = Opcode::SOFTMAX,
+                    .dest_addr = sram_ls_entry.first,
+                    .size = sram_ls_entry.second,
+                    .src_addrs = std::vector<addr_type>{sram_l_entry.first},
+                    .src_from_accum = true,
+                });
+                tile.instructions.push_back(Instruction{
+                    .opcode = Opcode::MOVOUT,
+                    .dest_addr = sram_ls_entry.first,
+                    .size = sram_ls_entry.second,
+                    .src_addrs = std::static_pointer_cast<NPUTensor>(_outputs[i])
+                                     ->_inners[h_idx]
+                                     ->get_all_addrs(),
+                    .operand_id = _OUTPUT_OPERAND,
+                });
+            }
+            continue;
+        }
+
+        // incremental phase: PIM path, one GWRITE per head
+        uint32_t ch = key->get_channel();
+        std::map<uint32_t, std::vector<addr_type>> sram_readres_addrs;
+
+        // tiles_per_chunk: rows per head = seq_len / (bank_per_ch × tokens_per_row) = 16
+        // readres_per_tile: token groups per bank per row = num_ele_per_row / dk = 4
+        //   → per tile: readres_per_tile READRES, each reading 32 banks = 128 outputs/tile
+        //   → 16 tiles × 128 = 2048 outputs per head ✓
+        uint32_t dk_local = _E / _nh;
+        uint32_t tokens_per_row = (_config.dram_page_size / _config.precision) / dk_local;
+        uint32_t readres_per_tile = tokens_per_row;  // = 4
+        uint32_t tiles_per_chunk =
+            key->get_allocated_seq_len() / (banks_per_channel * tokens_per_row);
+
+        for (int h = 0; h < (int)_nh; h++) {
+            addr_type q_addr = query->get_addr(std::vector<uint32_t>{(uint32_t)h, 0, 0});
+            std::pair<addr_type, uint32_t> sram_entry_for_gw = allocate_sram_addr(0, false);
+            tile.instructions.push_back(Instruction{
+                .opcode = Opcode::PIM_GWRITE,
+                .dest_addr = sram_entry_for_gw.first,
+                .size = 0,
+                .src_addrs = std::vector<addr_type>{q_addr},
+                .operand_id = _INPUT_OPERAND,
+            });
+
+            for (int ti = 0; ti < (int)tiles_per_chunk; ti++) {
+                uint32_t row_base = key->_rows[h * (int)tiles_per_chunk + ti];
+                uint32_t p_header_addr = AddressConfig::encode_pim_header(
+                    ch, row_base, false, _comps_per_head * readres_per_tile, readres_per_tile);
+                std::pair<addr_type, uint32_t> sram_phdr_entry = allocate_sram_addr(0, false);
+                tile.instructions.push_back(Instruction{
+                    .opcode = Opcode::PIM_HEADER,
+                    .dest_addr = sram_phdr_entry.first,
+                    .size = 0,
+                    .src_addrs = std::vector<addr_type>{p_header_addr},
+                    .operand_id = _INPUT_OPERAND,
+                });
+
+                // readres_per_tile token groups, each: comps_per_head COMPs + 1 READRES
+                for (int tg = 0; tg < (int)readres_per_tile; tg++) {
+                    auto sram_res_entry = allocate_sram_addr(banks_per_channel, false);
+                    addr_type sram_res_addr = sram_res_entry.first;
+                    uint64_t dram_addr = AddressConfig::encode_pim_comps_readres(
+                        ch, row_base, _comps_per_head, tg == (int)readres_per_tile - 1);
+
+                    if (_config.dram_type == DramType::NEWTON) {
+                        Instruction comp_inst{
+                            .opcode = Opcode::PIM_COMP,
+                            .dest_addr = sram_res_addr,
+                            .size = 0,
+                            .src_addrs = std::vector<addr_type>{dram_addr},
+                            .operand_id = _INPUT_OPERAND,
+                        };
+                        for (int j = 0; j < (int)_comps_per_head; j++)
+                            tile.instructions.push_back(comp_inst);
+                        tile.instructions.push_back(Instruction{
+                            .opcode = Opcode::PIM_READRES,
+                            .dest_addr = sram_res_addr,
+                            .size = sram_res_entry.second,
+                            .src_addrs = std::vector<addr_type>{dram_addr},
+                            .operand_id = _INPUT_OPERAND,
+                        });
+                    } else {
+                        tile.instructions.push_back(Instruction{
+                            .opcode = Opcode::PIM_COMPS_READRES,
+                            .dest_addr = sram_res_addr,
+                            .size = sram_res_entry.second,
+                            .src_addrs = std::vector<addr_type>{dram_addr},
+                            .operand_id = _INPUT_OPERAND,
+                        });
+                    }
+
+                    if (sram_readres_addrs.find(h) == sram_readres_addrs.end())
+                        sram_readres_addrs[h] = std::vector<addr_type>{sram_res_addr};
+                    else
+                        sram_readres_addrs[h].push_back(sram_res_addr);
+                }
+            }
+        }
+
+        for (int hi = 0; hi < (int)_nh; hi++) {
+            assert(sram_readres_addrs[hi].size() == tiles_per_chunk * readres_per_tile);
+            uint32_t column_height = key->_seq_len;
+            std::pair<addr_type, uint32_t> sram_acc_entry = allocate_sram_addr(column_height, true);
+
+            tile.instructions.push_back(Instruction{
+                .opcode = Opcode::SOFTMAX,
+                .dest_addr = sram_acc_entry.first,
+                .size = sram_acc_entry.second,
+                .src_addrs = sram_readres_addrs[hi],
+            });
+            tile.instructions.push_back(Instruction{
+                .opcode = Opcode::MOVOUT,
+                .dest_addr = sram_acc_entry.first,
+                .size = sram_acc_entry.second,
+                .src_addrs = std::static_pointer_cast<NPUTensor>(_outputs[i])
+                                 ->_inners[hi]
+                                 ->get_all_addrs(),
+                .operand_id = _OUTPUT_OPERAND,
+            });
+            counter_for_debug++;
+        }
+    }
+
+    return tile;
+}
+
+void NeuPIMSLogitSoftmax::calculate_loops() {
+    assert(sram_size_needed() < _config.spad_size KB / 2);
+
+    uint32_t datas_per_comp_cmd = _config.pim_comp_coverage;
+
+    // one chunk = one head; one GWRITE per head with Q[h, 0, :]
+    _chunks = _nh;
+    _heads_per_tile = 1;
+    _heads_in_last_chunk = 1;
+    _comps_per_head = (uint32_t)ceil((double)_dk / datas_per_comp_cmd);
+
+    spdlog::info("chunks (=nh): {}", _chunks);
+    spdlog::info("heads per tile: {}", _heads_per_tile);
+    spdlog::info("comps per head: {}", _comps_per_head);
+}
+
+
+void NeuPIMSLogitSoftmax::initialize_tiles_legacy() {
+    int num_npu_tiles = _req_idxs.size();
+    int prev_idx = 0;
+    for (int i = 0; i < num_npu_tiles; i++) {
+        int req_idx = _req_idxs[i];
+        if (i == num_npu_tiles - 1) {
+            assert(req_idx == _batch_size - 1);
+        }
+        _tiles.push_back(initialize_instructions_legacy(prev_idx, req_idx));
+        prev_idx = req_idx;
+    }
+}
+
+Tile NeuPIMSLogitSoftmax::initialize_instructions_legacy(int start, int end) {
+    uint32_t banks_per_channel = _config.dram_banks_per_ch;
+
     auto tile = Tile{
         .status = Tile::Status::INITIALIZED,
         .optype = get_name(),
@@ -300,7 +523,7 @@ Tile NeuPIMSLogitSoftmax::initialize_instructions(int start, int end) {
     return tile;
 }
 
-void NeuPIMSLogitSoftmax::calculate_loops() {
+void NeuPIMSLogitSoftmax::calculate_loops_legacy() {
     assert(sram_size_needed() < _config.spad_size KB / 2);
 
     uint32_t E = _config.model_n_embd / _config.n_tp;
@@ -315,10 +538,10 @@ void NeuPIMSLogitSoftmax::calculate_loops() {
         E % page_size == 0 ? _heads_per_tile : ceil((double)(E % page_size) / _dk);
     _comps_per_head = ceil((double)_dk / datas_per_comp_cmd);
 
-    spdlog::info("chunks: {}", _chunks);
-    spdlog::info("heads per tile: {}", _heads_per_tile);
-    spdlog::info("heads in last chunk: {}", _heads_in_last_chunk);
-    spdlog::info("comps per head: {}", _comps_per_head);
+    spdlog::info("[legacy] chunks: {}", _chunks);
+    spdlog::info("[legacy] heads per tile: {}", _heads_per_tile);
+    spdlog::info("[legacy] heads in last chunk: {}", _heads_in_last_chunk);
+    spdlog::info("[legacy] comps per head: {}", _comps_per_head);
 }
 
 uint32_t NeuPIMSLogitSoftmax::sram_size_needed() {

--- a/src/operations/NeuPIMSLogitSoftmax.h
+++ b/src/operations/NeuPIMSLogitSoftmax.h
@@ -32,6 +32,11 @@ class NeuPIMSLogitSoftmax : public Operation {
     Tile initialize_instructions(int start, int end);
     uint32_t sram_size_needed();
 
+    // legacy (original multi-head-per-chunk design)
+    void calculate_loops_legacy();
+    void initialize_tiles_legacy();
+    Tile initialize_instructions_legacy(int start, int end);
+
     //    private:
     //     addr_type _spad_addr;
     //     addr_type _acc_spad_addr;

--- a/src/tensor/PIMTensor.cc
+++ b/src/tensor/PIMTensor.cc
@@ -33,9 +33,15 @@ PIMTensor::PIMTensor(std::string name, uint32_t ch, std::vector<uint32_t> dims,
         num_alloc_iter = nh_local;             // 32 heads
     } 
     else {
-        // VALUE: allocate (E / bank_per_ch) rows
-        _num_rows_per_alloc = ceil((double)_E / (double)_bank_per_ch);
-        num_alloc_iter = ceil((double)_seq_len / (double)_num_ele_per_row);
+        // VALUE: per-head layout. rows_per_head = dk_tiles × seq_chunks.
+        // Row index: _rows[h * rows_per_head + ti * seq_chunks + ci]
+        // Total = rows_per_head × nh = 16 × 32 = 512 (same as original)
+        uint32_t nh_local = Config::global_config.model_n_head / Config::global_config.n_tp;
+        uint32_t dk_local = _E / nh_local;
+        uint32_t dk_tiles = (uint32_t)ceil((double)dk_local / _bank_per_ch);
+        uint32_t seq_chunks = (uint32_t)ceil((double)_seq_len / _num_ele_per_row);
+        _num_rows_per_alloc = dk_tiles * seq_chunks;  // = 16 rows per head
+        num_alloc_iter = nh_local;                    // = 32 heads
     }
 
     uint32_t num_required_alloc = num_alloc_iter * _num_rows_per_alloc;

--- a/src/tensor/PIMTensor.cc
+++ b/src/tensor/PIMTensor.cc
@@ -19,10 +19,20 @@ PIMTensor::PIMTensor(std::string name, uint32_t ch, std::vector<uint32_t> dims,
 
     uint32_t num_alloc_iter = 0;  // calculate # of allocation iterations based on seq_len.
     if (kv_type == PIMTensorKVType::KEY) {
-        // KEY: allocate (E / C) rows
-        _num_rows_per_alloc = ceil((double)_E / (double)_num_ele_per_row);
-        num_alloc_iter = ceil((double)_seq_len / (double)_bank_per_ch);
-    } else {
+        // KEY: per-head layout. One row = 1 head × tokens_per_row tokens.
+        // tokens_per_row = num_ele_per_row / dk = 512/128 = 4 (per bank: 4 tokens × 4 dk-elems = 16 elems)
+        // tiles_per_head = seq_len / (bank_per_ch × tokens_per_row) = 2048/128 = 16
+        // Row index: _rows[h * tiles_per_head + ti]  (head-first, consecutive per head)
+        // Total rows = tiles_per_head × nh = 16 × 32 = 512 (same as original layout)
+        uint32_t nh_local = Config::global_config.model_n_head / Config::global_config.n_tp;
+        uint32_t dk_local = _E / nh_local;
+        uint32_t tokens_per_row = _num_ele_per_row / dk_local;
+        uint32_t tiles_per_head =
+            (uint32_t)ceil((double)_seq_len / ((double)_bank_per_ch * tokens_per_row));
+        _num_rows_per_alloc = tiles_per_head;  // 16 rows per head
+        num_alloc_iter = nh_local;             // 32 heads
+    } 
+    else {
         // VALUE: allocate (E / bank_per_ch) rows
         _num_rows_per_alloc = ceil((double)_E / (double)_bank_per_ch);
         num_alloc_iter = ceil((double)_seq_len / (double)_num_ele_per_row);


### PR DESCRIPTION
Thank you for providing a great simulator. I have deeply checked the source codes, and found some issues inside the code. Currently, the repo's allocator for the Keys allocates multiple heads in one row. However, this requires multiple PIMGWrite instructions in the NeuPIMSLogitSoftmax operation, but there is only one now. We cannot write multiple Qs for different head together, since the PIMCompsReadRes instruction do not have any information that points where the compreadres will start in the Q.

Therefore, I modified the code to allocate one single head in one row. For example if num_head=32, head_dim=128, token_num=2048, the original version allocated 4 (512 (row size)/128 (one token size)) heads in one row, each saving one token. Because there are 32 banks in one channel, 2048/32=64 rows are required to contain 4 heads, and to contain all of the heads (32), we need 512 rows.

In my modification, it allocates 4 tokens of one head in a row, therefore we do not need to issue multiple PIMGWrites since the 4 tokens are for the same head. Therefore 1 head requires 16 rows, and 16*32=512 rows are required for saving all the heads. As a result, the total numbers of the row allocated are the same, but I think this modification is important for the remaining bug of PimGWrite, which is mentioned with notations at NeuPIMSLogitSoftmax.cc line 187-192 as FIXME. 

The same concept is added to the Values allocation and NeuPIMSAttend. If there is something wrong or something I have missed, I will strongly appreciate the maintainers when they expain the errors what I misconstrued.

Best thanks.